### PR TITLE
Fix polars error handling in parquet tiles

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use ::maplibre_legend::LegendError;
 use askama::Template;
 use bb8::RunError;
 use bb8_redis::redis::RedisError;
+use polars::error::PolarsError;
 use salvo::prelude::*;
 use std::num::TryFromIntError;
 use thiserror::Error;
@@ -89,6 +90,9 @@ pub enum AppError {
 
     #[error("Timeout error")]
     TimeoutError,
+
+    #[error("Polars error: {0}")]
+    Polars(#[from] PolarsError),
 
     #[error("MapLibre legend error: {0}")]
     Legend(#[from] LegendError),

--- a/src/services/parquet_tiles.rs
+++ b/src/services/parquet_tiles.rs
@@ -1,16 +1,18 @@
-use bytes::Bytes;
-use salvo::prelude::*;
-use crate::{error::AppResult, get_parquet_datasets};
 use crate::config::parquet::ParquetDataset;
+use crate::{error::AppResult, get_parquet_datasets};
+use bytes::Bytes;
 use polars::prelude::*;
-use std::path::{Path, PathBuf};
+use salvo::prelude::*;
 use std::fs;
+use std::path::{Path, PathBuf};
 
 fn tile_bbox(z: u32, x: u32, y: u32) -> (f64, f64, f64, f64) {
     let n = 2f64.powi(z as i32);
     let lon_deg_min = x as f64 / n * 360.0 - 180.0;
     let lon_deg_max = (x as f64 + 1.0) / n * 360.0 - 180.0;
-    let lat_rad_min = ((y as f64 + 1.0) / n * std::f64::consts::PI * -2.0).sinh().atan();
+    let lat_rad_min = ((y as f64 + 1.0) / n * std::f64::consts::PI * -2.0)
+        .sinh()
+        .atan();
     let lat_deg_min = lat_rad_min.to_degrees();
     let lat_rad_max = (y as f64 / n * std::f64::consts::PI * -2.0).sinh().atan();
     let lat_deg_max = lat_rad_max.to_degrees();
@@ -40,15 +42,22 @@ async fn generate_tile(dataset: &ParquetDataset, z: u32, x: u32, y: u32) -> AppR
     for file in files {
         let lf = LazyFrame::scan_parquet(file.to_str().unwrap(), Default::default())?;
         let df = lf
-            .filter(col(&dataset.lon_col).gt_eq(lit(min_lon))
-                .and(col(&dataset.lon_col).lt_eq(lit(max_lon)))
-                .and(col(&dataset.lat_col).gt_eq(lit(min_lat)))
-                .and(col(&dataset.lat_col).lt_eq(lit(max_lat))))
+            .filter(
+                col(&dataset.lon_col)
+                    .gt_eq(lit(min_lon))
+                    .and(col(&dataset.lon_col).lt_eq(lit(max_lon)))
+                    .and(col(&dataset.lat_col).gt_eq(lit(min_lat)))
+                    .and(col(&dataset.lat_col).lt_eq(lit(max_lat))),
+            )
             .select([col(&dataset.lon_col), col(&dataset.lat_col)])
             .collect()?;
-        for row in df.iter_rows() {
-            let lon: f64 = row[0].try_extract().unwrap_or(0.0);
-            let lat: f64 = row[1].try_extract().unwrap_or(0.0);
+
+        let lon_series = df.column(&dataset.lon_col)?.f64()?;
+        let lat_series = df.column(&dataset.lat_col)?.f64()?;
+
+        for i in 0..df.height() {
+            let lon = lon_series.get(i).unwrap_or(0.0);
+            let lat = lat_series.get(i).unwrap_or(0.0);
             points.push((lon, lat));
         }
     }
@@ -75,7 +84,9 @@ pub async fn get_parquet_tile(req: &mut Request, res: &mut Response) -> AppResul
         return Ok(());
     };
 
-    let tile = generate_tile(ds, z, x, y).await.unwrap_or_else(|_| Bytes::new());
+    let tile = generate_tile(ds, z, x, y)
+        .await
+        .unwrap_or_else(|_| Bytes::new());
     res.body(salvo::http::ResBody::Once(tile));
     Ok(())
 }


### PR DESCRIPTION
## Summary
- map Polars errors into `AppError`
- iterate over DataFrame rows using series accessors

## Testing
- `cargo build --release` *(fails: failed to download crates)*
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_688643be2f9483238861edd85cf2cb70