### PR TITLE
Remove leftover postgres references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3698,7 +3698,6 @@ dependencies = [
  "sqlx-core",
  "sqlx-macros",
  "sqlx-mysql",
- "sqlx-postgres",
  "sqlx-sqlite",
 ]
 
@@ -3769,7 +3768,6 @@ dependencies = [
  "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
- "sqlx-postgres",
  "sqlx-sqlite",
  "syn",
  "tokio",
@@ -3818,42 +3816,6 @@ dependencies = [
  "whoami",
 ]
 
-[[package]]
-name = "sqlx-postgres"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
-dependencies = [
- "atoi",
- "base64 0.22.1",
- "bitflags 2.9.1",
- "byteorder",
- "crc",
- "dotenvy",
- "etcetera",
- "futures-channel",
- "futures-core",
- "futures-util",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "home",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror 2.0.12",
- "tracing",
- "whoami",
-]
 
 [[package]]
 name = "sqlx-sqlite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tracing = "0.1"
 tracing-subscriber = {version="0.3", features = ["json", "env-filter"] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-sqlx = { version = "0.8", features = [ "runtime-tokio-rustls", "sqlite", "migrate" ] }
+sqlx = { version = "0.8", default-features = false, features = [ "runtime-tokio-rustls", "macros", "sqlite", "migrate" ] }
 
 inquire = { version = "0.7.5"}
 crossterm = "0.29"


### PR DESCRIPTION
## Summary
- clean up postgres references
- disable default SQLx features so the lock file no longer pulls postgres packages

## Testing
- `cargo check` *(fails: failed to get accept-language from index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6886883aaae48323a4dae67b8d35f52c